### PR TITLE
Make it possible to pass function space data for fibers

### DIFF
--- a/src/cardiac_geometries/geometry.py
+++ b/src/cardiac_geometries/geometry.py
@@ -98,7 +98,12 @@ class Geometry:
         self.mesh.comm.barrier()
 
     @classmethod
-    def from_file(cls, comm: MPI.Intracomm, path: str | Path) -> "Geometry":
+    def from_file(
+        cls,
+        comm: MPI.Intracomm,
+        path: str | Path,
+        function_space: dict[str, np.ndarray] | None = None,
+    ) -> "Geometry":
         path = Path(path)
 
         mesh = adios4dolfinx.read_mesh(comm=comm, filename=path)
@@ -118,9 +123,11 @@ class Geometry:
                 tags[name] = None
 
         functions = {}
-        function_space = adios4dolfinx.read_attributes(
-            comm=comm, filename=path, name="function_space"
-        )
+        if function_space is None:
+            function_space = adios4dolfinx.read_attributes(
+                comm=comm, filename=path, name="function_space"
+            )
+        assert isinstance(function_space, dict), "function_space must be a dictionary"
         for name, el in function_space.items():
             element = utils.array2element(el)
             V = dolfinx.fem.functionspace(mesh, element)

--- a/src/cardiac_geometries/geometry.py
+++ b/src/cardiac_geometries/geometry.py
@@ -102,7 +102,7 @@ class Geometry:
         cls,
         comm: MPI.Intracomm,
         path: str | Path,
-        function_space: dict[str, np.ndarray] | None = None,
+        function_space_data: dict[str, np.ndarray] | None = None,
     ) -> "Geometry":
         path = Path(path)
 
@@ -123,12 +123,12 @@ class Geometry:
                 tags[name] = None
 
         functions = {}
-        if function_space is None:
-            function_space = adios4dolfinx.read_attributes(
+        if function_space_data is None:
+            function_space_data = adios4dolfinx.read_attributes(
                 comm=comm, filename=path, name="function_space"
             )
-        assert isinstance(function_space, dict), "function_space must be a dictionary"
-        for name, el in function_space.items():
+        assert isinstance(function_space_data, dict), "function_space_data must be a dictionary"
+        for name, el in function_space_data.items():
             element = utils.array2element(el)
             V = dolfinx.fem.functionspace(mesh, element)
             f = dolfinx.fem.Function(V, name=name)


### PR DESCRIPTION
Due to https://github.com/ornladios/ADIOS2/issues/4471, the attributes read from the `.bp` might be invalid. Therefore we allow the user to pass in the function space data for the fibers that are otherwise read from the file as attributes. This can be done as follows
```
# Create the correct function space for the fibers
V = dolfinx.fem.functionspace(mesh, element)
# Create the fuction space dictionary
array = cardiac_geometries.utils.element2array(V.ufl_element())
function_space_data = {"f0": array, "s0": array, "n0": array}
cardiac_geometries.Geometry.from_file(path, function_space_data)
```