### PR TITLE
Skip tests that are affected by bug in gmsh

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from mpi4py import MPI
 
+import gmsh
 import pytest
 from click.testing import CliRunner
 
@@ -54,6 +55,7 @@ def test_script(fiber_space, script, tmp_path: Path):
         assert geo.f0 is not None
 
 
+@pytest.mark.skipif(gmsh.__version__ == "4.14.0", reason="GMSH 4.14.0 has a bug with fuse")
 @pytest.mark.skipif(not HAS_LDRB, reason="LDRB atlas is not installed")
 def test_biv_fibers(tmp_path: Path):
     runner = CliRunner()
@@ -81,6 +83,7 @@ def test_biv_fibers(tmp_path: Path):
     ],
     ids=["slab_in_bath", "biv_ellipsoid", "biv_ellipsoid_torso"],
 )
+@pytest.mark.skipif(gmsh.__version__ == "4.14.0", reason="GMSH 4.14.0 has a bug with fuse")
 def test_script_no_fibers(script, tmp_path: Path):
     runner = CliRunner()
 

--- a/tests/test_refinement.py
+++ b/tests/test_refinement.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from mpi4py import MPI
 
+import gmsh
 import pytest
 
 import cardiac_geometries as cg
@@ -52,6 +53,7 @@ def test_refine_analytic_fibers(script, tmp_path: Path):
     assert refined.mesh.geometry.index_map().size_global > geo.mesh.geometry.index_map().size_global
 
 
+@pytest.mark.skipif(gmsh.__version__ == "4.14.0", reason="GMSH 4.14.0 has a bug with fuse")
 @pytest.mark.skipif(not HAS_LDRB, reason="LDRB atlas is not installed")
 def test_refine_biv(tmp_path: Path):
     comm = MPI.COMM_WORLD


### PR DESCRIPTION
For some reason (probably related to https://gitlab.onelab.info/gmsh/gmsh/-/issues/3333) the fuse operation to create the RV endo doesn't work on gmsh version 4.14. Will skip the tests for now and hopefully it will be fixed in a future release. See https://github.com/ComputationalPhysiology/cardiac-geometriesx/issues/72