### PR TITLE
Flat cylinders

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,11 @@ classifiers = [
 ]
 keywords = ["cardiac", "geometry"]
 urls = {Homepage = "https://github.com/finsberg/cardiac-geometriesx" }
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
-    "fenics-dolfinx>=0.8.0",
+    "fenics-dolfinx>=0.9.0",
     "structlog",
-    "cardiac-geometries-core",
+    "cardiac-geometries-core>=0.4",
     "rich-click",
     "adios4dolfinx",
     "scifem",

--- a/src/cardiac_geometries/cli.py
+++ b/src/cardiac_geometries/cli.py
@@ -973,7 +973,7 @@ def slab_in_bath(
     geo.save(outdir / "slab_in_bath.bp")
 
 
-@click.command(help="Create BiV ellipsoidal geometry")
+@click.command(help="Create cylinder geometry")
 @click.argument(
     "outdir",
     required=True,
@@ -1069,6 +1069,120 @@ def cylinder(
     geo.save(outdir / "cylinder.bp")
 
 
+@click.command(help="Create cylinder geometry")
+@click.argument(
+    "outdir",
+    required=True,
+    type=click.Path(
+        file_okay=False,
+        dir_okay=True,
+        writable=True,
+        readable=True,
+        resolve_path=True,
+    ),
+)
+@click.option(
+    "--char-length",
+    default=10.0,
+    type=float,
+    help="Characteristic length of mesh",
+    show_default=True,
+)
+@click.option(
+    "--r-inner",
+    default=13.0,
+    type=float,
+    help="Inner radius of the cylinder",
+    show_default=True,
+)
+@click.option(
+    "--r-outer",
+    default=20.0,
+    type=float,
+    help="Outer radius of the cylinder",
+    show_default=True,
+)
+@click.option(
+    "--height",
+    default=40.0,
+    type=float,
+    help="Height of the cylinder",
+    show_default=True,
+)
+@click.option(
+    "--inner-flat-face-distance",
+    default=10.0,
+    type=float,
+    help="Distance from the inner flat face to the center",
+    show_default=True,
+)
+@click.option(
+    "--outer-flat-face-distance",
+    default=17.0,
+    type=float,
+    help="Distance from the outer flat face to the center",
+    show_default=True,
+)
+@click.option(
+    "--create-fibers",
+    default=False,
+    is_flag=True,
+    help="If True create analytic fibers",
+    show_default=True,
+)
+@click.option(
+    "--fiber-angle-endo",
+    default=-60,
+    type=float,
+    help="Angle for the endocardium",
+    show_default=True,
+)
+@click.option(
+    "--fiber-angle-epi",
+    default=+60,
+    type=float,
+    help="Angle for the epicardium",
+    show_default=True,
+)
+@click.option(
+    "--fiber-space",
+    default="P_1",
+    type=str,
+    help="Function space for fibers of the form family_degree",
+    show_default=True,
+)
+def cylinder_racetrack(
+    outdir: Path,
+    char_length: float = 10.0,
+    r_inner: float = 13.0,
+    r_outer: float = 20.0,
+    height: float = 40.0,
+    inner_flat_face_distance: float = 10.0,
+    outer_flat_face_distance: float = 17.0,
+    create_fibers: bool = False,
+    fiber_angle_endo: float = -60,
+    fiber_angle_epi: float = +60,
+    fiber_space: str = "P_1",
+):
+    outdir = Path(outdir)
+    outdir.mkdir(exist_ok=True)
+
+    geo = mesh.cylinder_racetrack(
+        outdir=outdir,
+        r_inner=r_inner,
+        r_outer=r_outer,
+        height=height,
+        inner_flat_face_distance=inner_flat_face_distance,
+        outer_flat_face_distance=outer_flat_face_distance,
+        char_length=char_length,
+        create_fibers=create_fibers,
+        fiber_angle_endo=fiber_angle_endo,
+        fiber_angle_epi=fiber_angle_epi,
+        fiber_space=fiber_space,
+    )
+    geo.save(outdir / "cylinder_racetrack.bp")
+
+
 @click.command("gui")
 def gui():
     # Make sure we can import the required packages
@@ -1088,3 +1202,4 @@ app.add_command(slab_in_bath)
 app.add_command(gui)
 app.add_command(ukb)
 app.add_command(cylinder)
+app.add_command(cylinder_racetrack)

--- a/src/cardiac_geometries/cli.py
+++ b/src/cardiac_geometries/cli.py
@@ -1069,7 +1069,7 @@ def cylinder(
     geo.save(outdir / "cylinder.bp")
 
 
-@click.command(help="Create cylinder geometry")
+@click.command(help="Create racetrack cylinder geometry")
 @click.argument(
     "outdir",
     required=True,
@@ -1183,6 +1183,120 @@ def cylinder_racetrack(
     geo.save(outdir / "cylinder_racetrack.bp")
 
 
+@click.command(help="Create D-shaped cylinder geometry")
+@click.argument(
+    "outdir",
+    required=True,
+    type=click.Path(
+        file_okay=False,
+        dir_okay=True,
+        writable=True,
+        readable=True,
+        resolve_path=True,
+    ),
+)
+@click.option(
+    "--char-length",
+    default=10.0,
+    type=float,
+    help="Characteristic length of mesh",
+    show_default=True,
+)
+@click.option(
+    "--r-inner",
+    default=13.0,
+    type=float,
+    help="Inner radius of the cylinder",
+    show_default=True,
+)
+@click.option(
+    "--r-outer",
+    default=20.0,
+    type=float,
+    help="Outer radius of the cylinder",
+    show_default=True,
+)
+@click.option(
+    "--height",
+    default=40.0,
+    type=float,
+    help="Height of the cylinder",
+    show_default=True,
+)
+@click.option(
+    "--inner-flat-face-distance",
+    default=10.0,
+    type=float,
+    help="Distance from the inner flat face to the center",
+    show_default=True,
+)
+@click.option(
+    "--outer-flat-face-distance",
+    default=17.0,
+    type=float,
+    help="Distance from the outer flat face to the center",
+    show_default=True,
+)
+@click.option(
+    "--create-fibers",
+    default=False,
+    is_flag=True,
+    help="If True create analytic fibers",
+    show_default=True,
+)
+@click.option(
+    "--fiber-angle-endo",
+    default=-60,
+    type=float,
+    help="Angle for the endocardium",
+    show_default=True,
+)
+@click.option(
+    "--fiber-angle-epi",
+    default=+60,
+    type=float,
+    help="Angle for the epicardium",
+    show_default=True,
+)
+@click.option(
+    "--fiber-space",
+    default="P_1",
+    type=str,
+    help="Function space for fibers of the form family_degree",
+    show_default=True,
+)
+def cylinder_D_shaped(
+    outdir: Path,
+    char_length: float = 10.0,
+    r_inner: float = 13.0,
+    r_outer: float = 20.0,
+    height: float = 40.0,
+    inner_flat_face_distance: float = 10.0,
+    outer_flat_face_distance: float = 17.0,
+    create_fibers: bool = False,
+    fiber_angle_endo: float = -60,
+    fiber_angle_epi: float = +60,
+    fiber_space: str = "P_1",
+):
+    outdir = Path(outdir)
+    outdir.mkdir(exist_ok=True)
+
+    geo = mesh.cylinder_D_shaped(
+        outdir=outdir,
+        r_inner=r_inner,
+        r_outer=r_outer,
+        height=height,
+        inner_flat_face_distance=inner_flat_face_distance,
+        outer_flat_face_distance=outer_flat_face_distance,
+        char_length=char_length,
+        create_fibers=create_fibers,
+        fiber_angle_endo=fiber_angle_endo,
+        fiber_angle_epi=fiber_angle_epi,
+        fiber_space=fiber_space,
+    )
+    geo.save(outdir / "cylinder_D_shaped.bp")
+
+
 @click.command("gui")
 def gui():
     # Make sure we can import the required packages
@@ -1203,3 +1317,4 @@ app.add_command(gui)
 app.add_command(ukb)
 app.add_command(cylinder)
 app.add_command(cylinder_racetrack)
+app.add_command(cylinder_D_shaped)

--- a/src/cardiac_geometries/fibers/cylinder_flat.py
+++ b/src/cardiac_geometries/fibers/cylinder_flat.py
@@ -1,0 +1,164 @@
+from pathlib import Path
+
+import dolfinx
+
+from . import cylinder, slab, utils
+
+
+def create_microstructure(
+    mesh: dolfinx.mesh.Mesh,
+    alpha_endo: float,
+    alpha_epi: float,
+    r_inner: float,
+    r_outer: float,
+    inner_flat_face_distance: float,
+    ffun: dolfinx.mesh.MeshTags,
+    markers: dict[str, tuple[int, int]],
+    function_space: str = "P_1",
+    outdir: str | Path | None = None,
+    **kwargs,
+) -> utils.Microstructure:
+    """Generate microstructure for cylinder
+
+    Parameters
+    ----------
+    mesh : dolfinx.mesh.Mesh
+        A cylinder mesh
+    alpha_endo : float
+        Angle on the endocardium
+    alpha_epi : float
+        Angle on the epicardium
+    r_inner : float
+        Inner radius
+    r_outer : float
+        Outer radius
+    function_space : str
+        Function space to interpolate the fibers, by default P_1
+    outdir : Optional[Union[str, Path]], optional
+        Output directory to store the results, by default None.
+        If no output directory is specified the results will not be stored,
+        but only returned.
+
+    Returns
+    -------
+    Microstructure
+        Tuple with fiber, sheet and sheet normal
+    """
+
+    system_cylinder = cylinder.compute_system(
+        mesh=mesh,
+        function_space=function_space,
+        r_inner=r_inner,
+        r_outer=r_outer,
+        alpha_endo=alpha_endo,
+        alpha_epi=alpha_epi,
+    )
+
+    x = system_cylinder.f0.function_space.tabulate_dof_coordinates().T[0]
+
+    f0_arr = system_cylinder.f0.x.array.reshape((-1, 3))
+    s0_arr = system_cylinder.s0.x.array.reshape((-1, 3))
+    n0_arr = system_cylinder.n0.x.array.reshape((-1, 3))
+
+    if "INSIDE_FLAT" in markers:
+        # This is the D-shaped cylinder
+        t = utils.laplace(
+            mesh,
+            ffun,
+            endo_marker=markers["INSIDE_FLAT"][0],
+            epi_marker=markers["OUTSIDE_FLAT"][0],
+            function_space=function_space,
+        )
+
+        if outdir is not None:
+            try:
+                with dolfinx.io.VTXWriter(
+                    mesh.comm, Path(outdir) / "laplace_flat.bp", [t], engine="BP4"
+                ) as file:
+                    file.write(0.0)
+            except RuntimeError:
+                pass
+
+        system_flat = slab.compute_system(
+            t,
+            alpha_endo=-alpha_endo,
+            alpha_epi=-alpha_epi,
+            endo_epi_axis="x",
+        )
+        flat_indices = x >= inner_flat_face_distance - 1e-8
+        f0_arr[flat_indices, :] = system_flat.f0.x.array.reshape((-1, 3))[flat_indices, :]
+        s0_arr[flat_indices, :] = system_flat.s0.x.array.reshape((-1, 3))[flat_indices, :]
+        n0_arr[flat_indices, :] = system_flat.n0.x.array.reshape((-1, 3))[flat_indices, :]
+
+    elif "INSIDE_FLAT1" in markers:
+        # This is the racetrack
+
+        # First side
+        t = utils.laplace(
+            mesh,
+            ffun,
+            endo_marker=markers["INSIDE_FLAT1"][0],
+            epi_marker=markers["OUTSIDE_FLAT1"][0],
+            function_space=function_space,
+        )
+
+        if outdir is not None:
+            try:
+                with dolfinx.io.VTXWriter(
+                    mesh.comm, Path(outdir) / "laplace_flat1.bp", [t], engine="BP4"
+                ) as file:
+                    file.write(0.0)
+            except RuntimeError:
+                pass
+
+        system_flat1 = slab.compute_system(
+            t,
+            alpha_endo=-alpha_endo,
+            alpha_epi=-alpha_epi,
+            endo_epi_axis="x",
+        )
+        flat_indices = x >= inner_flat_face_distance - 1e-8
+        f0_arr[flat_indices, :] = system_flat1.f0.x.array.reshape((-1, 3))[flat_indices, :]
+        s0_arr[flat_indices, :] = system_flat1.s0.x.array.reshape((-1, 3))[flat_indices, :]
+        n0_arr[flat_indices, :] = system_flat1.n0.x.array.reshape((-1, 3))[flat_indices, :]
+
+        # Second side
+        t = utils.laplace(
+            mesh,
+            ffun,
+            endo_marker=markers["INSIDE_FLAT2"][0],
+            epi_marker=markers["OUTSIDE_FLAT2"][0],
+            function_space=function_space,
+        )
+
+        if outdir is not None:
+            try:
+                with dolfinx.io.VTXWriter(
+                    mesh.comm, Path(outdir) / "laplace_flat2.bp", [t], engine="BP4"
+                ) as file:
+                    file.write(0.0)
+            except RuntimeError:
+                pass
+
+        system_flat1 = slab.compute_system(
+            t,
+            alpha_endo=alpha_endo,
+            alpha_epi=alpha_epi,
+            endo_epi_axis="x",
+        )
+        flat_indices = x <= -inner_flat_face_distance + 1e-8
+        f0_arr[flat_indices, :] = system_flat1.f0.x.array.reshape((-1, 3))[flat_indices, :]
+        s0_arr[flat_indices, :] = system_flat1.s0.x.array.reshape((-1, 3))[flat_indices, :]
+        n0_arr[flat_indices, :] = system_flat1.n0.x.array.reshape((-1, 3))[flat_indices, :]
+    else:
+        raise ValueError(
+            "Markers for flat faces not found. Please provide markers for the flat faces."
+        )
+    system_cylinder.f0.x.array[:] = f0_arr.reshape(-1)
+    system_cylinder.s0.x.array[:] = s0_arr.reshape(-1)
+    system_cylinder.n0.x.array[:] = n0_arr.reshape(-1)
+
+    if outdir is not None:
+        utils.save_microstructure(mesh, system_cylinder, outdir)
+
+    return system_cylinder

--- a/src/cardiac_geometries/fibers/slab.py
+++ b/src/cardiac_geometries/fibers/slab.py
@@ -11,6 +11,7 @@ def compute_system(
     t_func: dolfinx.fem.Function,
     alpha_endo: float = -60,
     alpha_epi: float = 60,
+    endo_epi_axis="y",
 ) -> utils.Microstructure:
     """Compute ldrb system for slab, assuming linear
     angle between endo and epi
@@ -39,13 +40,32 @@ def compute_system(
 
     t = t_func.x.array
 
-    f0 = np.array(
-        [
-            np.cos(alpha(t)),
-            np.zeros_like(t),
-            np.sin(alpha(t)),
-        ],
-    )
+    if endo_epi_axis == "y":
+        f0 = np.array(
+            [
+                np.cos(alpha(t)),
+                np.zeros_like(t),
+                np.sin(alpha(t)),
+            ],
+        )
+    elif endo_epi_axis == "z":
+        f0 = np.array(
+            [
+                np.cos(alpha(t)),
+                np.sin(alpha(t)),
+                np.zeros_like(t),
+            ],
+        )
+    elif endo_epi_axis == "x":
+        f0 = np.array(
+            [
+                np.zeros_like(t),
+                np.cos(alpha(t)),
+                np.sin(alpha(t)),
+            ],
+        )
+    else:
+        raise ValueError(f"Unknown endo_epi_axis: {endo_epi_axis}")
 
     s0 = np.array(
         [

--- a/src/cardiac_geometries/mesh.py
+++ b/src/cardiac_geometries/mesh.py
@@ -1281,3 +1281,127 @@ def cylinder_racetrack(
     geo = Geometry.from_folder(comm=comm, folder=outdir)
 
     return geo
+
+
+def cylinder_D_shaped(
+    outdir: Path | str,
+    r_inner: float = 13.0,
+    r_outer: float = 20.0,
+    height: float = 40.0,
+    inner_flat_face_distance: float = 10.0,
+    outer_flat_face_distance: float = 17.0,
+    char_length: float = 10.0,
+    create_fibers: bool = False,
+    fiber_angle_endo: float = 60,
+    fiber_angle_epi: float = -60,
+    fiber_space: str = "P_1",
+    aha: bool = True,
+    verbose: bool = False,
+    comm: MPI.Comm = MPI.COMM_WORLD,
+) -> Geometry:
+    """Create a D-shaped thick cylindrical shell mesh using GMSH.
+
+    Both the inner and outer surfaces have two flat faces on opposite sides.
+
+    Parameters
+    ----------
+    outdir : Optional[Path], optional
+        Directory where to save the results.
+    r_inner : float, optional
+        Radius on the endocardium layer, by default 13.0
+    r_outer : float, optional
+       Radius on the epicardium layer, by default 20.0
+    height : float, optional
+        Longest radius on the endocardium layer, by default 10.0
+    inner_flat_face_distance : float
+        The distance of the inner flat face from the center (along the x-axis).
+        This value must be less than inner_radius. Default is 10.0.
+    outer_flat_face_distance : float
+        The distance of the outer flat face from the center (along the x-axis).
+        This value must be less than outer_radius. Default is 17.0.
+    char_length : float, optional
+        Characteristic length of mesh, by default 10.0
+    create_fibers : bool, optional
+        If True create analytic fibers, by default False
+    fiber_angle_endo : float, optional
+        Angle for the endocardium, by default 60
+    fiber_angle_epi : float, optional
+        Angle for the epicardium, by default -60
+    fiber_space : str, optional
+        Function space for fibers of the form family_degree, by default "P_1"
+    aha : bool, optional
+        If True create 17-segment AHA regions
+    verbose : bool, optional
+        If True print information from gmsh, by default False
+    comm : MPI.Comm, optional
+        MPI communicator, by default MPI.COMM_WORLD
+
+    Returns
+    -------
+    cardiac_geometries.geometry.Geometry
+        A Geometry with the mesh, markers, markers functions and fibers.
+
+    """
+
+    outdir = Path(outdir)
+    mesh_name = outdir / "cylinder_D_shaped.msh"
+    if comm.rank == 0:
+        outdir.mkdir(exist_ok=True, parents=True)
+
+        with open(outdir / "info.json", "w") as f:
+            json.dump(
+                {
+                    "r_inner": r_inner,
+                    "r_outer": r_outer,
+                    "height": height,
+                    "inner_flat_face_distance": inner_flat_face_distance,
+                    "outer_flat_face_distance": outer_flat_face_distance,
+                    "char_length": char_length,
+                    "create_fibers": create_fibers,
+                    "fiber_angle_endo": fiber_angle_endo,
+                    "fiber_angle_epi": fiber_angle_epi,
+                    "fiber_space": fiber_space,
+                    "aha": aha,
+                    "mesh_type": "cylinder",
+                    "cardiac_geometry_version": __version__,
+                    "timestamp": datetime.datetime.now().isoformat(),
+                },
+                f,
+                indent=2,
+                default=utils.json_serial,
+            )
+
+        cgc.cylinder_D_shaped(
+            inner_radius=r_inner,
+            outer_radius=r_outer,
+            inner_flat_face_distance=inner_flat_face_distance,
+            outer_flat_face_distance=outer_flat_face_distance,
+            height=height,
+            mesh_name=mesh_name.as_posix(),
+            char_length=char_length,
+            verbose=verbose,
+        )
+    comm.barrier()
+
+    geometry = utils.gmsh2dolfin(comm=comm, msh_file=mesh_name)
+
+    if comm.rank == 0:
+        with open(outdir / "markers.json", "w") as f:
+            json.dump(geometry.markers, f, default=utils.json_serial)
+
+    if create_fibers:
+        from .fibers.cylinder import create_microstructure
+
+        create_microstructure(
+            mesh=geometry.mesh,
+            function_space=fiber_space,
+            r_inner=r_inner,
+            r_outer=r_outer,
+            alpha_endo=fiber_angle_endo,
+            alpha_epi=fiber_angle_epi,
+            outdir=outdir,
+        )
+
+    geo = Geometry.from_folder(comm=comm, folder=outdir)
+
+    return geo

--- a/src/cardiac_geometries/mesh.py
+++ b/src/cardiac_geometries/mesh.py
@@ -1266,13 +1266,16 @@ def cylinder_racetrack(
             json.dump(geometry.markers, f, default=utils.json_serial)
 
     if create_fibers:
-        from .fibers.cylinder import create_microstructure
+        from .fibers.cylinder_flat import create_microstructure
 
         create_microstructure(
             mesh=geometry.mesh,
             function_space=fiber_space,
             r_inner=r_inner,
             r_outer=r_outer,
+            inner_flat_face_distance=inner_flat_face_distance,
+            ffun=geometry.ffun,
+            markers=geometry.markers,
             alpha_endo=fiber_angle_endo,
             alpha_epi=fiber_angle_epi,
             outdir=outdir,
@@ -1390,13 +1393,16 @@ def cylinder_D_shaped(
             json.dump(geometry.markers, f, default=utils.json_serial)
 
     if create_fibers:
-        from .fibers.cylinder import create_microstructure
+        from .fibers.cylinder_flat import create_microstructure
 
         create_microstructure(
             mesh=geometry.mesh,
             function_space=fiber_space,
             r_inner=r_inner,
             r_outer=r_outer,
+            inner_flat_face_distance=inner_flat_face_distance,
+            ffun=geometry.ffun,
+            markers=geometry.markers,
             alpha_endo=fiber_angle_endo,
             alpha_epi=fiber_angle_epi,
             outdir=outdir,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,8 +31,10 @@ MPI_SIZE = MPI.COMM_WORLD.size
         cli.slab,
         cli.lv_ellipsoid,
         cli.cylinder,
+        cli.cylinder_D_shaped,
+        cli.cylinder_racetrack,
     ],
-    ids=["slab", "lv_ellipsoid", "cylinder"],
+    ids=["slab", "lv_ellipsoid", "cylinder", "cylinder_D_shaped", "cylinder_racetrack"],
 )
 @pytest.mark.parametrize("fiber_space", [None, "P_1", "P_2", "Quadrature_2", "DG_1"])
 def test_script(fiber_space, script, tmp_path: Path):


### PR DESCRIPTION
Add racetrack cylinder and D-shaped cylinder as implemented in https://github.com/ComputationalPhysiology/cardiac-geometries-core/pull/27. Use combination of cylinder-based and slab-based fibers to define appropriate fibers (see screenshot). The fibers on one side of the racetrack is inverted but the fibers are usually considered bi-directional so this should be fine. 

<img width="641" height="354" alt="Screenshot 2025-08-12 at 21 44 49" src="https://github.com/user-attachments/assets/4752f2e5-1b7b-4b1d-a2e8-db6c165f59fc" />
